### PR TITLE
VEGA-2734 - исправление стилей для корректной работы Layout внутри main

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -32,6 +32,7 @@
         flex-grow: 1;
         display: flex;
         flex-direction: column;
+        overflow: hidden;
       }
 
       .main > div:not(:empty) {

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -38,6 +38,7 @@
       .main > div:not(:empty) {
         flex-grow: 1;
         display: flex;
+        overflow: hidden;
       }
     </style>
     <!--


### PR DESCRIPTION
Jira issue: VEGA-2734
https://jira.konakov.tv/browse/VEGA-2734

## Описание изменений

Похоже что изза верстки grid Layout если не выставить - overflow: hidden у оборачивающих элементов, то происходит ситуация (см. скриншот в задаче)

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [x] Документация: отражены все изменения в API конфигов и описаны важные особенности реализации или использования
- [x] Конфигурационные файлы: новые файлы или изменения текущих были проверены в тестовых репозиториях

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [ ] Коммиты: проименованы в соответствии с [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
