### PR TITLE
VEGA-783: Интегрировать конкурентный доступ в проектном эндпоинте

### DIFF
--- a/.graphqlrc.yaml
+++ b/.graphqlrc.yaml
@@ -1,0 +1,3 @@
+schema: "graphql.schema.json"
+include: "src/**/*.{graphql,ts,tsx}"
+exclude: "**/*.test.{ts,tsx}"

--- a/src/services/graphql-client/project-diff-resolver/combined-fetch-result.test.ts
+++ b/src/services/graphql-client/project-diff-resolver/combined-fetch-result.test.ts
@@ -1,0 +1,54 @@
+import { GraphQLError } from 'graphql';
+
+import { CombinedFetchResult } from './combined-fetch-result';
+
+describe('CombinedFetchResult', () => {
+  let sut: CombinedFetchResult;
+
+  beforeEach(() => {
+    sut = new CombinedFetchResult();
+  });
+
+  test('начальное значение', () => {
+    expect(sut.get()).toStrictEqual({});
+  });
+
+  test('добавление нескольких результатов', () => {
+    const error1 = new GraphQLError('test');
+    const error2 = new GraphQLError('test 2');
+
+    sut.combine({ data: { test: 'test' } });
+    sut.combine({ data: { test2: 'test2' } });
+
+    expect(sut.get()).toStrictEqual({
+      data: { test: 'test', test2: 'test2' },
+    });
+
+    sut.combine({ errors: [error1] });
+    sut.combine({ errors: [error2] });
+
+    expect(sut.get()).toStrictEqual({
+      data: { test: 'test', test2: 'test2' },
+      errors: [error1, error2],
+    });
+
+    sut.combine({ context: { ctx: 'ctx' } });
+    sut.combine({ context: { ctx2: 'ctx2' } });
+
+    expect(sut.get()).toStrictEqual({
+      data: { test: 'test', test2: 'test2' },
+      context: { ctx: 'ctx', ctx2: 'ctx2' },
+      errors: [error1, error2],
+    });
+
+    sut.combine({ extensions: { ext: 'ext' } });
+    sut.combine({ extensions: { ext2: 'ext2' } });
+
+    expect(sut.get()).toStrictEqual({
+      data: { test: 'test', test2: 'test2' },
+      context: { ctx: 'ctx', ctx2: 'ctx2' },
+      extensions: { ext: 'ext', ext2: 'ext2' },
+      errors: [error1, error2],
+    });
+  });
+});

--- a/src/services/graphql-client/project-diff-resolver/combined-fetch-result.ts
+++ b/src/services/graphql-client/project-diff-resolver/combined-fetch-result.ts
@@ -1,0 +1,40 @@
+import { FetchResult } from '@apollo/client';
+
+export class CombinedFetchResult {
+  private fetchResult: FetchResult;
+
+  constructor() {
+    this.fetchResult = {};
+  }
+
+  public combine(incoming: FetchResult): void {
+    this.combineProp('data', incoming);
+    this.combineProp('errors', incoming);
+    this.combineProp('context', incoming);
+    this.combineProp('extensions', incoming);
+  }
+
+  private combineProp<P extends keyof FetchResult>(prop: P, incoming: FetchResult): void {
+    const existing = this.fetchResult;
+
+    if (prop === 'errors') {
+      if (existing.errors === undefined && incoming.errors !== undefined) {
+        existing.errors = incoming.errors;
+      } else if (existing.errors !== undefined) {
+        existing.errors = existing.errors.concat(incoming.errors ?? []);
+      }
+
+      return;
+    }
+
+    if (existing[prop] === undefined && incoming[prop] !== undefined) {
+      this.fetchResult[prop] = incoming[prop];
+    } else if (existing[prop] !== undefined) {
+      this.fetchResult[prop] = { ...existing[prop], ...(incoming[prop] ?? {}) };
+    }
+  }
+
+  get(): FetchResult {
+    return this.fetchResult;
+  }
+}

--- a/src/services/graphql-client/project-diff-resolver/error.ts
+++ b/src/services/graphql-client/project-diff-resolver/error.ts
@@ -1,3 +1,4 @@
+// istanbul ignore next проверяется на уровне typescript
 export class ProjectDiffResolverError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/services/graphql-client/project-diff-resolver/error.ts
+++ b/src/services/graphql-client/project-diff-resolver/error.ts
@@ -1,4 +1,3 @@
-// istanbul ignore next проверяется на уровне typescript
 export class ProjectDiffResolverError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/services/graphql-client/project-diff-resolver/project-diff-resolver-link.test.ts
+++ b/src/services/graphql-client/project-diff-resolver/project-diff-resolver-link.test.ts
@@ -41,9 +41,9 @@ describe('ProjectDiffResolverLink', () => {
     return new ProjectDiffResolverLink({
       errorTypename,
       projectAccessor: {
-        fromDiffError: (data, local) => ({
+        fromDiffError: (data) => ({
           remote: data.result.remote,
-          local: { ...local, ...data.result.remote },
+          local: {},
         }),
       },
       ...defaults,
@@ -294,8 +294,7 @@ describe('ProjectDiffResolverLink', () => {
         testMutationOne: {
           result: {
             vid,
-            foo: 'foo_2',
-            bar: 'bar_1',
+            data: [{ a: 2 }, { b: 2 }],
             version: 3,
             __typename: 'Test',
           },
@@ -317,8 +316,7 @@ describe('ProjectDiffResolverLink', () => {
             result: {
               remote: {
                 vid,
-                foo: 'foo_1',
-                bar: 'bar_1',
+                data: [{ a: 2 }, { b: 1 }],
                 version: 2,
                 __typename: 'Test',
               },
@@ -333,7 +331,6 @@ describe('ProjectDiffResolverLink', () => {
           testMutationOne: {
             result: {
               vid,
-              bar: 'bar_1',
               ...patchedVars,
               version: 3,
               __typename: 'Test',
@@ -349,18 +346,31 @@ describe('ProjectDiffResolverLink', () => {
       mergeStrategy: {
         default: 'smart',
       },
+      projectAccessor: {
+        fromDiffError(data) {
+          return {
+            remote: data.result.remote,
+            local: {
+              vid,
+              data: [{ a: 1 }, { b: 1 }],
+              version: 1,
+            },
+          };
+        },
+      },
     });
 
     const variables = {
       vid,
-      foo: 'foo_2',
+      data: [{ a: 1 }, { b: 2 }],
       version: 1,
     };
 
     const result = await toPromise(execute(link, { query, variables }));
 
     expect(patchedVars).toStrictEqual({
-      ...variables,
+      vid,
+      data: [{ a: 2 }, { b: 2 }],
       version: 2,
     });
 
@@ -448,6 +458,18 @@ describe('ProjectDiffResolverLink', () => {
     const link = createLink(stub, {
       mergeStrategy: {
         default: 'smart',
+      },
+      projectAccessor: {
+        fromDiffError(data) {
+          return {
+            remote: data.result.remote,
+            local: {
+              vid,
+              foo: 'foo_1',
+              version: 1,
+            },
+          };
+        },
       },
     });
 

--- a/src/services/graphql-client/project-diff-resolver/project-diff-resolver-link.test.ts
+++ b/src/services/graphql-client/project-diff-resolver/project-diff-resolver-link.test.ts
@@ -210,11 +210,11 @@ describe('ProjectDiffResolverLink', () => {
         data = {
           testMutationOne: {
             result: {
-              local: {
+              remote: {
                 vid,
-                foo: 'foo',
-                bar: 'bar',
-                version: 1,
+                foo: 'foo_1',
+                bar: 'bar_1',
+                version: 2,
                 __typename: 'Test',
               },
               remote: {
@@ -315,12 +315,6 @@ describe('ProjectDiffResolverLink', () => {
         data = {
           testMutationOne: {
             result: {
-              local: {
-                vid,
-                foo: 'foo',
-                version: 1,
-                __typename: 'Test',
-              },
               remote: {
                 vid,
                 foo: 'foo',

--- a/src/services/graphql-client/project-diff-resolver/project-diff-resolver-link.ts
+++ b/src/services/graphql-client/project-diff-resolver/project-diff-resolver-link.ts
@@ -8,6 +8,7 @@ import {
 } from '@apollo/client';
 import { BREAK, DocumentNode, visit } from 'graphql';
 
+import { ProjectDiffResolverError } from './error';
 import type { Data, MergeStrategy, ProjectAccessor } from './project-diff-resolving-operation';
 import { ProjectDiffResolvingOperation } from './project-diff-resolving-operation';
 
@@ -29,7 +30,7 @@ export class ProjectDiffResolverLink extends ApolloLink {
 
   private readonly maxAttempts: number;
 
-  private readonly projectAccessor: ProjectAccessor;
+  private readonly projectAccessor: Partial<ProjectAccessor> | undefined;
 
   private readonly mergeStrategy: MergeStrategy;
 
@@ -60,15 +61,15 @@ export class ProjectDiffResolverLink extends ApolloLink {
     };
   }
 
-  private static makeProjectAccessor(accessor?: Partial<ProjectAccessor>): ProjectAccessor {
+  private static makeProjectAccessor(accessor: Partial<ProjectAccessor>): ProjectAccessor {
     const identity = <T>(value: T): T => value;
     const merge = (a: Data, b: Data): Data => ({ ...a, ...b });
 
-    const {
-      fromDiffError = () => ({ remote: {}, local: {} }),
-      fromVariables = identity,
-      toVariables = merge,
-    } = accessor ?? {};
+    const { fromDiffError, fromVariables = identity, toVariables = merge } = accessor;
+
+    if (typeof fromDiffError !== 'function') {
+      throw new ProjectDiffResolverError('projectAccessor.fromDiffError is required');
+    }
 
     return {
       fromDiffError,
@@ -81,9 +82,7 @@ export class ProjectDiffResolverLink extends ApolloLink {
     super();
     this.errorTypename = defaultOptions.errorTypename;
     this.maxAttempts = defaultOptions.maxAttempts ?? 5;
-    this.projectAccessor = ProjectDiffResolverLink.makeProjectAccessor(
-      defaultOptions.projectAccessor,
-    );
+    this.projectAccessor = defaultOptions.projectAccessor;
 
     this.mergeStrategy = ProjectDiffResolverLink.makeMergeStrategy(
       defaultOptions.mergeStrategy ?? {},

--- a/src/services/graphql-client/project-diff-resolver/project-diff-resolver-link.ts
+++ b/src/services/graphql-client/project-diff-resolver/project-diff-resolver-link.ts
@@ -97,12 +97,18 @@ export class ProjectDiffResolverLink extends ApolloLink {
       return nextLink(operation);
     }
 
+    const { projectDiffResolving } = operation.getContext();
+
+    if (projectDiffResolving === undefined) {
+      return nextLink(operation);
+    }
+
     const {
       maxAttempts = this.maxAttempts,
       errorTypename = this.errorTypename,
       projectAccessor = {},
       mergeStrategy = {},
-    } = operation.getContext().projectDiffResolving ?? {};
+    } = projectDiffResolving;
 
     const resolving = new ProjectDiffResolvingOperation({
       maxAttempts,

--- a/src/services/graphql-client/project-diff-resolver/project-diff-resolver-link.ts
+++ b/src/services/graphql-client/project-diff-resolver/project-diff-resolver-link.ts
@@ -85,9 +85,12 @@ export class ProjectDiffResolverLink extends ApolloLink {
       defaultOptions.projectAccessor,
     );
 
-    this.mergeStrategy = {
-      default: 'replace',
-    };
+    this.mergeStrategy = ProjectDiffResolverLink.makeMergeStrategy(
+      defaultOptions.mergeStrategy ?? {},
+      {
+        default: 'replace',
+      },
+    );
   }
 
   request(operation: Operation, nextLink: NextLink): Observable<FetchResult> {

--- a/src/services/graphql-client/project-diff-resolver/project-diff-resolver.ts
+++ b/src/services/graphql-client/project-diff-resolver/project-diff-resolver.ts
@@ -1,0 +1,59 @@
+import type { Config as DiffPatcherConfig } from 'jsondiffpatch';
+import * as jsonDiffPatch from 'jsondiffpatch';
+
+interface MergeStrategyParams {
+  default: 'replace' | 'smart';
+}
+
+interface ResolverParams {
+  mergeStrategy: MergeStrategyParams;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyObject = Record<string | number, any>;
+
+interface Input<T extends AnyObject> {
+  local: T;
+  localChanges: T;
+  remote: T;
+}
+
+export class ProjectDiffResolver {
+  private mergeStrategy: MergeStrategyParams;
+
+  private diffPatcher: jsonDiffPatch.DiffPatcher;
+
+  constructor(params: ResolverParams) {
+    const { mergeStrategy } = params;
+
+    this.mergeStrategy = mergeStrategy;
+
+    const diffPatcherConfig: DiffPatcherConfig = {
+      objectHash(item, index) {
+        return item?.vid || `$$index:${index}`;
+      },
+      textDiff: {
+        minLength: Infinity,
+      },
+      propertyFilter(name) {
+        return !['__typename', 'version', 'vid'].includes(name);
+      },
+    };
+
+    this.diffPatcher = jsonDiffPatch.create(diffPatcherConfig);
+  }
+
+  merge<T extends AnyObject>(input: Input<T>): T {
+    const { local, remote, localChanges } = input;
+
+    if (this.mergeStrategy.default === 'smart') {
+      const diff = this.diffPatcher.diff(local, localChanges);
+
+      if (diff !== undefined) {
+        return this.diffPatcher.patch(remote, diff);
+      }
+    }
+
+    return { ...localChanges, version: remote.version };
+  }
+}

--- a/src/services/graphql-client/project-diff-resolver/project-diff-resolving-operation.ts
+++ b/src/services/graphql-client/project-diff-resolver/project-diff-resolving-operation.ts
@@ -21,6 +21,8 @@ interface MutationResult {
   result: Data & {
     __typename: string;
   };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 }
 
 export interface ProjectAccessor<
@@ -40,7 +42,7 @@ export interface MergeStrategy {
 }
 
 interface Options<V = OperationVariables, D = Data> {
-  maxAttempts?: number;
+  maxAttempts: number;
   errorTypename: string;
   operation: Operation;
   nextLink: NextLink;
@@ -83,7 +85,7 @@ export class ProjectDiffResolvingOperation {
     this.subscription = null;
 
     this.attempt = 1;
-    this.maxAttempts = options.maxAttempts ?? 5;
+    this.maxAttempts = options.maxAttempts;
 
     this.fetchResult = new CombinedFetchResult();
 

--- a/src/services/graphql-client/project-diff-resolver/project-diff-resolving-operation.ts
+++ b/src/services/graphql-client/project-diff-resolver/project-diff-resolving-operation.ts
@@ -283,21 +283,11 @@ export class ProjectDiffResolvingOperation {
 
     const localChanges = this.projectAccessor.fromVariables(variables);
 
-    const affectedRemote: Data = {
-      version: remote.version,
-    };
-
-    Object.keys(localChanges).forEach((key) => {
-      if (remote[key] !== undefined) {
-        affectedRemote[key] = remote[key];
-      }
-    });
-
     if (this.mergeStrategy.default === 'smart') {
       const diff = this.resolver.diff(local, localChanges);
 
       if (diff !== undefined) {
-        const patched = this.resolver.patch({ ...affectedRemote }, diff);
+        const patched = this.resolver.patch(remote, diff);
 
         const updatedVars = this.projectAccessor.toVariables(variables, omitTypename(patched));
 

--- a/src/services/graphql-client/project-diff-resolver/project-diff-resolving-operation.ts
+++ b/src/services/graphql-client/project-diff-resolver/project-diff-resolving-operation.ts
@@ -90,6 +90,9 @@ export class ProjectDiffResolvingOperation {
     this.mergeStrategy = options.mergeStrategy;
 
     this.resolver = jsonDiffPatch.create({
+      objectHash(item, index) {
+        return item?.vid || `$$index:${index}`;
+      },
       textDiff: {
         minLength: Infinity,
       },

--- a/src/services/graphql-client/project-diff-resolver/project-diff-resolving-operation.ts
+++ b/src/services/graphql-client/project-diff-resolver/project-diff-resolving-operation.ts
@@ -193,6 +193,7 @@ export class ProjectDiffResolvingOperation {
     const observable = new Observable<FetchResult>((observer) => {
       this.observer = observer;
       return () => {
+        // istanbul ignore else
         if (this.subscription !== null) {
           this.subscription.unsubscribe();
         }
@@ -220,10 +221,12 @@ export class ProjectDiffResolvingOperation {
   }
 
   private done(data: FetchResult): void {
+    // istanbul ignore if не должно происходить
     if (this.observer === null) {
       throw new ProjectDiffResolverError('Internal bug. Observer is null!');
     }
 
+    // istanbul ignore else
     if (typeof this.observer.next === 'function' && typeof this.observer.complete === 'function') {
       this.observer.next(data);
       this.observer.complete();
@@ -231,6 +234,7 @@ export class ProjectDiffResolvingOperation {
       return;
     }
 
+    // istanbul ignore next не должно происходить
     throw new ProjectDiffResolverError('Internal bug. Incompatible observer!');
   }
 
@@ -254,6 +258,7 @@ export class ProjectDiffResolvingOperation {
   }
 
   private onError(error: unknown): void {
+    // istanbul ignore else
     if (this.observer !== null && typeof this.observer.error === 'function') {
       this.observer.error(error);
     }
@@ -272,12 +277,13 @@ export class ProjectDiffResolvingOperation {
   }
 
   private resolveConflicts(mutations: MutationResult[]): void {
+    // istanbul ignore if не должно происходить
     if (mutations.length === 0) {
       throw new ProjectDiffResolverError('Internal bug. No mutations with error!');
     }
 
     const { variables } = this.operation;
-    const [versions] = mutations.map((m) => this.projectAccessor.fromDiffError(m));
+    const versions = this.projectAccessor.fromDiffError(mutations[0]);
 
     const { remote, local } = versions;
 

--- a/src/services/graphql-client/project-diff-resolver/project-diff-resolving-operation.ts
+++ b/src/services/graphql-client/project-diff-resolver/project-diff-resolving-operation.ts
@@ -28,7 +28,10 @@ export interface ProjectAccessor<
   Variables extends OperationVariables = OperationVariables,
   ProjectData extends Data = Data
 > {
-  fromDiffError(mutationResult: MutationResult): { local: ProjectData; remote: ProjectData };
+  fromDiffError(
+    mutationResult: MutationResult,
+    local: ProjectData,
+  ): { local: ProjectData; remote: ProjectData };
   fromVariables(variables: Variables): ProjectData;
   toVariables(variables: Variables, data: ProjectData): Variables;
 }
@@ -261,11 +264,10 @@ export class ProjectDiffResolvingOperation {
     }
 
     const { variables } = this.operation;
-    const versions = this.projectAccessor.fromDiffError(mutations[0]);
+    const localChanges = this.projectAccessor.fromVariables(variables);
+    const versions = this.projectAccessor.fromDiffError(mutations[0], localChanges);
 
     const { remote, local } = versions;
-
-    const localChanges = this.projectAccessor.fromVariables(variables);
 
     if (this.mergeStrategy.default === 'smart') {
       const diff = this.resolver.diff(local, localChanges);

--- a/src/services/graphql-client/utils.test.ts
+++ b/src/services/graphql-client/utils.test.ts
@@ -1,0 +1,58 @@
+import * as utils from './utils';
+
+describe('utils', () => {
+  describe('omitTypename', () => {
+    const simpleInput = {
+      __typename: 'test',
+      value: 'test',
+    };
+
+    const simpleOutput = {
+      value: 'test',
+    };
+
+    const complexInput = {
+      ...simpleInput,
+      nestedObject: {
+        ...simpleInput,
+        nested: {
+          object: simpleInput,
+          array: [simpleInput],
+        },
+      },
+      nestedArray: [[simpleInput], [simpleInput]],
+    };
+
+    const complexOutput = {
+      ...simpleOutput,
+      nestedObject: {
+        ...simpleOutput,
+        nested: {
+          object: simpleOutput,
+          array: [simpleOutput],
+        },
+      },
+      nestedArray: [[simpleOutput], [simpleOutput]],
+    };
+    test('обрабатывает примитивы', () => {
+      expect(utils.omitTypename('')).toBe('');
+      expect(utils.omitTypename(0)).toBe(0);
+      expect(utils.omitTypename(null)).toBe(null);
+      expect(utils.omitTypename(undefined)).toBe(undefined);
+      expect(utils.omitTypename(true)).toBe(true);
+      expect(utils.omitTypename(false)).toBe(false);
+    });
+
+    test('удаляет поле из объекта', () => {
+      expect(utils.omitTypename(simpleInput)).toStrictEqual(simpleOutput);
+    });
+
+    test('обрабатывает массивы', () => {
+      expect(utils.omitTypename([simpleInput])).toStrictEqual([simpleOutput]);
+    });
+
+    test('обрабатывает вложенные структуры', () => {
+      expect(utils.omitTypename(complexInput)).toStrictEqual(complexOutput);
+    });
+  });
+});

--- a/src/services/graphql-client/utils.ts
+++ b/src/services/graphql-client/utils.ts
@@ -1,0 +1,31 @@
+type AnyValue = any; // eslint-disable-line @typescript-eslint/no-explicit-any
+type AnyObject = Record<string, AnyValue>;
+
+export function isObject(value: AnyValue): value is AnyObject {
+  return typeof value === 'object' && value !== null;
+}
+
+export function omitTypename(input: AnyValue): AnyValue {
+  if (Array.isArray(input)) {
+    return input.map(omitTypename);
+  }
+
+  if (isObject(input)) {
+    const data = { ...input };
+
+    Object.keys(input).forEach((key) => {
+      if (key === '__typename') {
+        delete data[key];
+        return;
+      }
+
+      if (isObject(data[key])) {
+        data[key] = omitTypename(data[key]);
+      }
+    });
+
+    return data;
+  }
+
+  return input;
+}


### PR DESCRIPTION
Ссылка Jira CSSSR https://jira.csssr.io/browse/VEGA-783

## Описание изменений
- Доработана поддержка проектного эндпоинта
- Из обновленных переменных удаляются поля `__typename`

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [ ] Документация: отражены все изменения в API конфигов и описаны важные особенности реализации или использования
- [ ] Конфигурационные файлы: новые файлы или изменения текущих были проверены в тестовых репозиториях

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [ ] Коммиты: проименованы в соответствии с [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
