### PR TITLE
[VEGA-3425] feat(components): Получать ошибку доступа с бэкенда

### DIFF
--- a/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
+++ b/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
@@ -96,7 +96,8 @@ describe('ApplicationRoutes', () => {
         status: 403,
       });
 
-      const userMessage = 'Ошибка аутентификации. Права доступа в систему Вега 2.0 отсутствуют';
+      const userMessage =
+        'Вы не включены в рабочую группу ВЕГА 2.0. Необходимо запросить доступ к Вега 2.0 через СУИД';
 
       const { shell } = renderComponent({ isAuth: false, route: '/login' });
 

--- a/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
+++ b/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
@@ -90,10 +90,10 @@ describe('ApplicationRoutes', () => {
       });
     });
 
-    test('при ошибке авторизации со статусом 401 и кодом "PERMISSION_DENIED" происходит редирект на страницу ошибки', async () => {
+    test('при ошибке авторизации со статусом 403 и кодом "PERMISSION_DENIED" происходит редирект на страницу ошибки', async () => {
       fetchMock.mock(`/auth/jwt/obtain`, {
         body: { Error: { code: 'PERMISSION_DENIED', message: 'permission_denied' } },
-        status: 401,
+        status: 403,
       });
 
       const userMessage = 'Ошибка аутентификации. Права доступа в систему Вега 2.0 отсутствуют';

--- a/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
+++ b/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
@@ -131,6 +131,26 @@ describe('ApplicationRoutes', () => {
       });
     });
 
+    test('при авторизации при redirectTo = permission_denied не происходит редирект', async () => {
+      fetchMock.mock(`/auth/jwt/obtain`, {
+        first_name: 'First',
+        last_name: 'Last',
+        jwt_for_access: mockValidToken(),
+        jwt_for_refresh: mockValidToken(),
+      });
+
+      const { shell } = renderComponent({
+        isAuth: false,
+        route: `/login?redirectTo=${encodeURIComponent('/permission_denied')}`,
+      });
+
+      login();
+
+      await waitFor(() => {
+        expect(shell.history.location.pathname).toBe('/projects');
+      });
+    });
+
     test('при очистке токенов и попытке перейти на другую страницу происходит переход на страницу авторизации', async () => {
       const { shell } = renderComponent({ isAuth: true, route: '/projects' });
 

--- a/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
+++ b/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
@@ -90,6 +90,27 @@ describe('ApplicationRoutes', () => {
       });
     });
 
+    test('при ошибке авторизации со статусом 401 и кодом "PERMISSION_DENIED" происходит редирект на страницу ошибки', async () => {
+      fetchMock.mock(`/auth/jwt/obtain`, {
+        body: { Error: { code: 'PERMISSION_DENIED', message: 'permission_denied' } },
+        status: 401,
+      });
+
+      const userMessage =
+        'Ошибка аутентификации. Вы не включены в рабочую группу Вега 2.0. Обратитесь в службу технической поддержки';
+
+      const { shell } = renderComponent({ isAuth: false, route: '/login' });
+
+      login();
+
+      await act(async () => {
+        await fetchMock.flush();
+      });
+
+      expect(shell.history.location.pathname).toBe('/permission_denied');
+      expect(screen.getByText(userMessage)).toBeInTheDocument();
+    });
+
     test('при авторизации при наличии redirectTo происходит редирект на redirectTo', async () => {
       fetchMock.mock(`/auth/jwt/obtain`, {
         first_name: 'First',
@@ -213,7 +234,7 @@ describe('ApplicationRoutes', () => {
       expect(await screen.findByText(/500/)).toBeInTheDocument();
     });
 
-    test('при ошибке с кодом 401 создается уведомление', async () => {
+    test('при ошибке со статусом 401', async () => {
       fetchMock.mock('/graphql', { status: 401 });
 
       const { shell } = renderComponent({ isAuth: true, route: createProjectRoute(uuid()) });
@@ -227,7 +248,7 @@ describe('ApplicationRoutes', () => {
       );
     });
 
-    test('при ошибке с кодом 401 происходит разлогин пользователя', async () => {
+    test('при ошибке со статусом 401 происходит разлогин пользователя', async () => {
       fetchMock.mock('/graphql', { status: 401 });
 
       renderComponent();

--- a/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
+++ b/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
@@ -96,8 +96,7 @@ describe('ApplicationRoutes', () => {
         status: 401,
       });
 
-      const userMessage =
-        'Ошибка аутентификации. Вы не включены в рабочую группу Вега 2.0. Обратитесь в службу технической поддержки';
+      const userMessage = 'Ошибка аутентификации. Права доступа в систему Вега 2.0 отсутствуют';
 
       const { shell } = renderComponent({ isAuth: false, route: '/login' });
 

--- a/src/components/ApplicationRoutes/ApplicationRoutes.tsx
+++ b/src/components/ApplicationRoutes/ApplicationRoutes.tsx
@@ -160,6 +160,7 @@ export const ApplicationRoutes = (): React.ReactElement => {
         <LogoutView />
       </Route>
       <Route path={PERMISSION_DENIED_PATH}>
+        {isLoggedIn && <Redirect to="/projects" />}
         <PermissionDeniedView />
       </Route>
       <Route path="/projects">

--- a/src/components/ApplicationRoutes/ApplicationRoutes.tsx
+++ b/src/components/ApplicationRoutes/ApplicationRoutes.tsx
@@ -12,9 +12,11 @@ import { ErrorView } from '../Error';
 import { Header } from '../Header';
 
 import { NotFoundView } from './NotFoundView';
+import { PermissionDeniedView } from './PermissionDeniedView';
 import { ProjectRoutes } from './ProjectRoutes';
 
 const AUTH_PATH = '/login';
+const PERMISSION_DENIED_PATH = '/permission_denied';
 
 export const AUTH_ERROR_MESSAGE =
   'Что-то пошло не так. Для повторного входа в\u00A0систему введите свои e-mail и\u00A0пароль';
@@ -131,7 +133,11 @@ export const ApplicationRoutes = (): React.ReactElement => {
     return path;
   };
 
-  if (!isLoggedIn && location.pathname !== AUTH_PATH) {
+  if (
+    !isLoggedIn &&
+    location.pathname !== AUTH_PATH &&
+    location.pathname !== PERMISSION_DENIED_PATH
+  ) {
     return <Redirect to={getLoginPath()} />;
   }
 
@@ -152,6 +158,9 @@ export const ApplicationRoutes = (): React.ReactElement => {
       </Route>
       <Route path="/logout">
         <LogoutView />
+      </Route>
+      <Route path={PERMISSION_DENIED_PATH}>
+        <PermissionDeniedView />
       </Route>
       <Route path="/projects">
         <Header />

--- a/src/components/ApplicationRoutes/PermissionDeniedView.tsx
+++ b/src/components/ApplicationRoutes/PermissionDeniedView.tsx
@@ -6,6 +6,6 @@ export const PermissionDeniedView: React.FC = () => (
   <ErrorView
     code={403}
     message="permission_denied"
-    userMessage="Ошибка аутентификации. Права доступа в систему Вега 2.0 отсутствуют"
+    userMessage="Вы не включены в рабочую группу ВЕГА 2.0. Необходимо запросить доступ к Вега 2.0 через СУИД"
   />
 );

--- a/src/components/ApplicationRoutes/PermissionDeniedView.tsx
+++ b/src/components/ApplicationRoutes/PermissionDeniedView.tsx
@@ -4,7 +4,7 @@ import { ErrorView } from '../Error';
 
 export const PermissionDeniedView: React.FC = () => (
   <ErrorView
-    code={401}
+    code={403}
     message="permission_denied"
     userMessage="Ошибка аутентификации. Права доступа в систему Вега 2.0 отсутствуют"
   />

--- a/src/components/ApplicationRoutes/PermissionDeniedView.tsx
+++ b/src/components/ApplicationRoutes/PermissionDeniedView.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { ErrorView } from '../Error';
+
+export const PermissionDeniedView: React.FC = () => (
+  <ErrorView
+    code={401}
+    message="permission_denied"
+    userMessage="Ошибка аутентификации. Вы не включены в рабочую группу Вега 2.0. Обратитесь в службу технической поддержки"
+  />
+);

--- a/src/components/ApplicationRoutes/PermissionDeniedView.tsx
+++ b/src/components/ApplicationRoutes/PermissionDeniedView.tsx
@@ -6,6 +6,6 @@ export const PermissionDeniedView: React.FC = () => (
   <ErrorView
     code={401}
     message="permission_denied"
-    userMessage="Ошибка аутентификации. Вы не включены в рабочую группу Вега 2.0. Обратитесь в службу технической поддержки"
+    userMessage="Ошибка аутентификации. Права доступа в систему Вега 2.0 отсутствуют"
   />
 );

--- a/src/components/AuthForm/AuthForm.test.tsx
+++ b/src/components/AuthForm/AuthForm.test.tsx
@@ -96,6 +96,23 @@ describe('AuthForm', () => {
     });
   });
 
+  test('если код ошибки PERMISSION_DENIED, то проиcходит переход на страницу ошибки', async () => {
+    const body = 'permission_denied';
+    const onLoginError = jest
+      .fn()
+      .mockRejectedValueOnce({ code: 'PERMISSION_DENIED', message: body });
+
+    const { shell } = renderComponent({ onLogin: onLoginError });
+
+    login();
+
+    await waitFor(() => {
+      expect(shell.history.location.pathname).toBe('/permission_denied');
+    });
+
+    expect(shell.notifications.getAll()).toEqual([]);
+  });
+
   test('если код ошибки не AUTH_ERROR, то в нотификации отобразится сообщение с сервера', async () => {
     const body = 'Ошибка валидации';
     const onLoginError = jest

--- a/src/components/AuthForm/AuthForm.tsx
+++ b/src/components/AuthForm/AuthForm.tsx
@@ -13,7 +13,7 @@ import { createValidate, validators } from './validation';
 
 import './AuthForm.css';
 
-type LoginError = {
+export type LoginError = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 };

--- a/src/components/AuthForm/AuthForm.tsx
+++ b/src/components/AuthForm/AuthForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Form as FinalForm } from 'react-final-form';
+import { useHistory } from 'react-router-dom';
 import { Button, Form, Logo, Text } from '@gpn-prototypes/vega-ui';
 
 import { useShell } from '../../app';
@@ -59,6 +60,8 @@ export const LOGIN_ERROR_NOTIFICATION_KEY = 'login-error-alert';
 export const AuthForm: AuthFormComponent = (props) => {
   const { onLogin, containerClassName } = props;
 
+  const history = useHistory();
+
   const { notifications } = useShell();
 
   const [isFetching, setIsFetching] = useState(false);
@@ -75,6 +78,13 @@ export const AuthForm: AuthFormComponent = (props) => {
     }
 
     onLogin(values).catch((error: LoginError) => {
+      setIsFetching(false);
+
+      if (error.code === 'PERMISSION_DENIED') {
+        history.push('/permission_denied');
+        return;
+      }
+
       const body = error.code === 'AUTH_ERROR' ? authErrorMessage : error.message;
 
       if (error) {
@@ -84,8 +94,6 @@ export const AuthForm: AuthFormComponent = (props) => {
           view: 'alert',
         });
       }
-
-      setIsFetching(false);
     });
   };
 

--- a/src/components/AuthForm/index.ts
+++ b/src/components/AuthForm/index.ts
@@ -1,1 +1,6 @@
-export { AuthForm, AUTH_ERROR_NOTIFICATION_KEY, LOGIN_ERROR_NOTIFICATION_KEY } from './AuthForm';
+export {
+  AuthForm,
+  AUTH_ERROR_NOTIFICATION_KEY,
+  LOGIN_ERROR_NOTIFICATION_KEY,
+  LoginError,
+} from './AuthForm';

--- a/src/components/AuthPage/AuthPage.test.tsx
+++ b/src/components/AuthPage/AuthPage.test.tsx
@@ -89,7 +89,18 @@ describe('AuthPage', () => {
     });
 
     test('обработка ошибки', async () => {
-      fetchMock.mock(`/auth/sso/login`, () => Promise.reject());
+      fetchMock.mock(
+        { url: `/auth/sso/login`, method: 'POST' },
+        {
+          status: 401,
+          body: JSON.stringify({
+            Error: {
+              code: 'Ошибка',
+              message: 'Описание ошибки',
+            },
+          }),
+        },
+      );
 
       const { shell } = renderComponent();
 

--- a/src/components/AuthPage/AuthPage.test.tsx
+++ b/src/components/AuthPage/AuthPage.test.tsx
@@ -66,6 +66,31 @@ describe('AuthPage', () => {
         expect(shell.identity.isLoggedIn()).toBeFalsy();
       });
     });
+
+    test('обработка ошибки PERMISSION_DENIED', async () => {
+      fetchMock.mock(
+        { url: `/auth/jwt/obtain`, method: 'POST' },
+        {
+          status: 401,
+          body: JSON.stringify({
+            Error: {
+              code: 'PERMISSION_DENIED',
+              message: 'permission_denied',
+            },
+          }),
+        },
+      );
+
+      const { shell } = renderComponent();
+
+      expect(shell.identity.isLoggedIn()).toBeFalsy();
+
+      login();
+
+      await waitFor(() => {
+        expect(shell.history.location.pathname).toBe('/permission_denied');
+      });
+    });
   });
 
   describe('авторизация через SSO', () => {
@@ -90,7 +115,7 @@ describe('AuthPage', () => {
 
     test('обработка ошибки', async () => {
       fetchMock.mock(
-        { url: `/auth/sso/login`, method: 'POST' },
+        { url: `/auth/sso/login`, method: 'GET' },
         {
           status: 401,
           body: JSON.stringify({
@@ -110,6 +135,27 @@ describe('AuthPage', () => {
             expect.objectContaining({ id: LOGIN_SSO_ERROR_NOTIFICATION_KEY, view: 'alert' }),
           ]),
         );
+      });
+    });
+
+    test('обработка ошибки PERMISSION_DENIED', async () => {
+      fetchMock.mock(
+        { url: `/auth/sso/login`, method: 'GET' },
+        {
+          status: 401,
+          body: JSON.stringify({
+            Error: {
+              code: 'PERMISSION_DENIED',
+              message: 'permission_denied',
+            },
+          }),
+        },
+      );
+
+      const { shell } = renderComponent();
+
+      await waitFor(() => {
+        expect(shell.history.location.pathname).toBe('/permission_denied');
       });
     });
 

--- a/src/components/AuthPage/AuthPage.test.tsx
+++ b/src/components/AuthPage/AuthPage.test.tsx
@@ -71,7 +71,7 @@ describe('AuthPage', () => {
       fetchMock.mock(
         { url: `/auth/jwt/obtain`, method: 'POST' },
         {
-          status: 401,
+          status: 403,
           body: JSON.stringify({
             Error: {
               code: 'PERMISSION_DENIED',
@@ -142,7 +142,7 @@ describe('AuthPage', () => {
       fetchMock.mock(
         { url: `/auth/sso/login`, method: 'GET' },
         {
-          status: 401,
+          status: 403,
           body: JSON.stringify({
             Error: {
               code: 'PERMISSION_DENIED',

--- a/src/components/AuthPage/AuthPage.tsx
+++ b/src/components/AuthPage/AuthPage.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Carousel, Loader } from '@gpn-prototypes/vega-ui';
 
 import { useShell } from '../../app';
-import { AuthForm } from '../AuthForm';
+import { AuthForm, LoginError } from '../AuthForm';
 
 import imgCreate from './images/carousel-create-project.png';
 import imgRb from './images/carousel-rb.png';
@@ -36,6 +37,7 @@ export const LOGIN_SSO_ERROR_NOTIFICATION_KEY = 'login-sso-error-alert';
 
 export const AuthPage: AuthPageType = () => {
   const { identity, notifications } = useShell();
+  const history = useHistory();
 
   const [slideIdx, setSlideIdx] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
@@ -48,7 +50,12 @@ export const AuthPage: AuthPageType = () => {
         notifications.remove(LOGIN_SSO_ERROR_NOTIFICATION_KEY);
       }
 
-      identity?.authSSO().catch(() => {
+      identity?.authSSO().catch((error: LoginError) => {
+        if (error.code === 'PERMISSION_DENIED') {
+          history.push('/permission_denied');
+          return;
+        }
+
         const body = 'При входе возникла ошибка, войдите с помощью учетной записи';
 
         notifications.add({

--- a/src/components/Error/Error.css
+++ b/src/components/Error/Error.css
@@ -37,7 +37,14 @@
     white-space: pre-line;
   }
 
+  &__ButtonWrapper {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
   &__Button {
+    margin: 0 var(--space-2xs);
     margin-top: var(--space-s);
   }
 

--- a/src/components/Error/ErrorView.test.tsx
+++ b/src/components/Error/ErrorView.test.tsx
@@ -39,7 +39,7 @@ function findProjectsButton(): HTMLElement {
 }
 
 function findCreateAppealButton(): HTMLElement {
-  return findButton(labels.createAppeal);
+  return findButton(labels.suidButton);
 }
 
 function renderComponent(props: Partial<ErrorViewProps> = {}): RenderResult {
@@ -120,8 +120,7 @@ describe('ErrorView', () => {
   });
 
   describe('401 ошибка', () => {
-    const userMessage =
-      'Ошибка аутентификации. Вы не включены в рабочую группу Вега 2.0. Обратитесь в службу технической поддержки';
+    const userMessage = 'Ошибка аутентификации. Права доступа в систему Вега 2.0 отсутствуют';
     beforeEach(() => {
       renderComponent({
         code: 401,

--- a/src/components/Error/ErrorView.test.tsx
+++ b/src/components/Error/ErrorView.test.tsx
@@ -38,8 +38,12 @@ function findProjectsButton(): HTMLElement {
   return findButton(labels.projectButton);
 }
 
-function findCreateAppealButton(): HTMLElement {
+function findSuidButton(): HTMLElement {
   return findButton(labels.suidButton);
+}
+
+function findReturnButton(): HTMLElement {
+  return findButton(labels.returnButton);
 }
 
 function renderComponent(props: Partial<ErrorViewProps> = {}): RenderResult {
@@ -130,17 +134,31 @@ describe('ErrorView', () => {
     });
 
     test('рендерится кнопка отправления обращения в техподдержку', () => {
-      expect(findCreateAppealButton()).toBeInTheDocument();
+      expect(findSuidButton()).toBeInTheDocument();
     });
 
-    test('при нажатии на кнопку происходит открытие страницы выбор', () => {
+    test('рендерится кнопка возвращения на страницу логина', () => {
+      expect(findReturnButton()).toBeInTheDocument();
+    });
+
+    test('при нажатии на кнопку перехода в суид происходит открытие новой страницы', () => {
       const spy = jest.spyOn(window, 'open');
 
-      const button = findCreateAppealButton();
+      const button = findSuidButton();
 
       userEvent.click(button);
 
       expect(spy).toBeCalledWith('https://suid.gazprom-neft.local/', '_blank', 'noreferrer=true');
+    });
+
+    test('при нажатии на кнопку назад происходит переход на страницу логина', () => {
+      const spy = jest.spyOn(history, 'push');
+
+      const button = findReturnButton();
+
+      userEvent.click(button);
+
+      expect(spy).toBeCalledWith('/login');
     });
 
     test('отображается корректный текст ошибки при наличии userMessage', () => {

--- a/src/components/Error/ErrorView.test.tsx
+++ b/src/components/Error/ErrorView.test.tsx
@@ -123,11 +123,11 @@ describe('ErrorView', () => {
     });
   });
 
-  describe('401 ошибка', () => {
+  describe('403 ошибка', () => {
     const userMessage = 'Ошибка аутентификации. Права доступа в систему Вега 2.0 отсутствуют';
     beforeEach(() => {
       renderComponent({
-        code: 401,
+        code: 403,
         message: 'permission_denied',
         userMessage,
       });

--- a/src/components/Error/ErrorView.test.tsx
+++ b/src/components/Error/ErrorView.test.tsx
@@ -38,6 +38,10 @@ function findProjectsButton(): HTMLElement {
   return findButton(labels.projectButton);
 }
 
+function findCreateAppealButton(): HTMLElement {
+  return findButton(labels.createAppeal);
+}
+
 function renderComponent(props: Partial<ErrorViewProps> = {}): RenderResult {
   return render(
     <Router history={history}>
@@ -112,6 +116,36 @@ describe('ErrorView', () => {
 
     test('отображается корректный текст ошибки при наличии userMessage', () => {
       expect(screen.getByLabelText(labels.errorText)).toHaveTextContent(USER_MESSAGE);
+    });
+  });
+
+  describe('401 ошибка', () => {
+    const userMessage =
+      'Ошибка аутентификации. Вы не включены в рабочую группу Вега 2.0. Обратитесь в службу технической поддержки';
+    beforeEach(() => {
+      renderComponent({
+        code: 401,
+        message: 'permission_denied',
+        userMessage,
+      });
+    });
+
+    test('рендерится кнопка отправления обращения в техподдержку', () => {
+      expect(findCreateAppealButton()).toBeInTheDocument();
+    });
+
+    test('при нажатии на кнопку происходит открытие страницы выбор', () => {
+      const spy = jest.spyOn(window, 'open');
+
+      const button = findCreateAppealButton();
+
+      userEvent.click(button);
+
+      expect(spy).toBeCalledWith('https://suid.gazprom-neft.local/', '_blank', 'noreferrer=true');
+    });
+
+    test('отображается корректный текст ошибки при наличии userMessage', () => {
+      expect(screen.getByLabelText(labels.errorText)).toHaveTextContent(userMessage);
     });
   });
 });

--- a/src/components/Error/ErrorView.tsx
+++ b/src/components/Error/ErrorView.tsx
@@ -25,7 +25,7 @@ export enum labels {
   errorText = 'Текст ошибки',
   reloadButton = 'Попробовать снова',
   projectButton = 'В список проектов',
-  createAppeal = 'Создать обращение',
+  suidButton = 'Перейти в суид',
   body = 'Ошибка от сервера',
 }
 
@@ -47,7 +47,7 @@ const ErrorViewButton = (props: ErrorViewButtonProps): React.ReactElement => {
 
   switch (code) {
     case 401: {
-      buttonText = labels.createAppeal;
+      buttonText = labels.suidButton;
       break;
     }
     case 404: {

--- a/src/components/Error/ErrorView.tsx
+++ b/src/components/Error/ErrorView.tsx
@@ -25,7 +25,7 @@ export enum labels {
   errorText = 'Текст ошибки',
   reloadButton = 'Попробовать снова',
   projectButton = 'В список проектов',
-  suidButton = 'Перейти в суид',
+  suidButton = 'Перейти в СУИД',
   returnButton = 'Назад',
   body = 'Ошибка от сервера',
 }

--- a/src/components/Error/ErrorView.tsx
+++ b/src/components/Error/ErrorView.tsx
@@ -47,7 +47,7 @@ const ErrorViewButton = (props: ErrorViewButtonProps): React.ReactElement => {
   let buttonText = labels.reloadButton;
 
   switch (code) {
-    case 401: {
+    case 403: {
       buttonText = labels.suidButton;
       break;
     }
@@ -60,7 +60,7 @@ const ErrorViewButton = (props: ErrorViewButtonProps): React.ReactElement => {
   }
 
   const handleClick = (): void => {
-    if (code === 401) {
+    if (code === 403) {
       window.open('https://suid.gazprom-neft.local/', '_blank', 'noreferrer=true');
     }
 
@@ -76,7 +76,7 @@ const ErrorViewButton = (props: ErrorViewButtonProps): React.ReactElement => {
 
   return (
     <div className={cnErrorView('ButtonsWrapper')}>
-      {code === 401 && (
+      {code === 403 && (
         <Button
           onClick={() => history.push('/login')}
           size="s"

--- a/src/components/Error/ErrorView.tsx
+++ b/src/components/Error/ErrorView.tsx
@@ -26,6 +26,7 @@ export enum labels {
   reloadButton = 'Попробовать снова',
   projectButton = 'В список проектов',
   suidButton = 'Перейти в суид',
+  returnButton = 'Назад',
   body = 'Ошибка от сервера',
 }
 
@@ -74,16 +75,30 @@ const ErrorViewButton = (props: ErrorViewButtonProps): React.ReactElement => {
   };
 
   return (
-    <Button
-      onClick={handleClick}
-      size="s"
-      role="button"
-      name={buttonText}
-      view="ghost"
-      label={buttonText}
-      aria-label={buttonText}
-      className={cnErrorView('Button').toString()}
-    />
+    <div className={cnErrorView('ButtonsWrapper')}>
+      {code === 401 && (
+        <Button
+          onClick={() => history.push('/login')}
+          size="s"
+          role="button"
+          name={labels.returnButton}
+          view="ghost"
+          label={labels.returnButton}
+          aria-label={labels.returnButton}
+          className={cnErrorView('Button').toString()}
+        />
+      )}
+      <Button
+        onClick={handleClick}
+        size="s"
+        role="button"
+        name={buttonText}
+        view="ghost"
+        label={buttonText}
+        aria-label={buttonText}
+        className={cnErrorView('Button').toString()}
+      />
+    </div>
   );
 };
 

--- a/src/components/Error/ErrorView.tsx
+++ b/src/components/Error/ErrorView.tsx
@@ -21,12 +21,13 @@ import './Error.css';
 
 export type ErrorViewProps = ServerError;
 
-export const labels = {
-  errorText: 'Текст ошибки',
-  reloadButton: 'Попробовать снова',
-  projectButton: 'В список проектов',
-  body: 'Ошибка от сервера',
-} as const;
+export enum labels {
+  errorText = 'Текст ошибки',
+  reloadButton = 'Попробовать снова',
+  projectButton = 'В список проектов',
+  createAppeal = 'Создать обращение',
+  body = 'Ошибка от сервера',
+}
 
 export const TIME_TO_RELOAD_SEC = 60;
 
@@ -42,9 +43,26 @@ type ErrorViewButtonProps = Pick<ErrorViewProps, 'code'> & {
 const ErrorViewButton = (props: ErrorViewButtonProps): React.ReactElement => {
   const { code, reloadInterval } = props;
   const history = useHistory();
-  const buttonText = code === 500 ? labels.reloadButton : labels.projectButton;
+  let buttonText = labels.reloadButton;
+
+  switch (code) {
+    case 401: {
+      buttonText = labels.createAppeal;
+      break;
+    }
+    case 404: {
+      buttonText = labels.projectButton;
+      break;
+    }
+    default:
+      break;
+  }
 
   const handleClick = (): void => {
+    if (code === 401) {
+      window.open('https://suid.gazprom-neft.local/', '_blank', 'noreferrer=true');
+    }
+
     if (code === 404) {
       history.push('/projects');
     }

--- a/src/services/api-client/api-client.ts
+++ b/src/services/api-client/api-client.ts
@@ -33,6 +33,8 @@ type FailedResponse = {
 type ErrorMessageFunction = (error: string | number) => string;
 
 export const ERROR_MESSAGE_FUNCTIONS = {
+  PERMISSION_DENIED: (): string =>
+    'Ошибка аутентификации. Права доступа в систему Вега 2.0 отсутствуют',
   AUTH: (error: string | number): string =>
     `При входе в систему возникла ошибка: ${error}. Попробуйте снова или обратитесь в Службу технической поддержки`,
   DEFAULT: (error: string | number): string => error.toString(),
@@ -87,7 +89,12 @@ export class APIClient {
       return data;
     }
 
-    const errorMessageFunction = ERROR_MESSAGE_FUNCTIONS.AUTH;
+    let errorMessageFunction = ERROR_MESSAGE_FUNCTIONS.AUTH;
+
+    if (response.status === 403) {
+      errorMessageFunction = ERROR_MESSAGE_FUNCTIONS.PERMISSION_DENIED;
+    }
+
     return handleResponseError(response, errorMessageFunction);
   };
 
@@ -103,7 +110,12 @@ export class APIClient {
       return data;
     }
 
-    const errorMessageFunction = ERROR_MESSAGE_FUNCTIONS.AUTH;
+    let errorMessageFunction = ERROR_MESSAGE_FUNCTIONS.AUTH;
+
+    if (response.status === 403) {
+      errorMessageFunction = ERROR_MESSAGE_FUNCTIONS.PERMISSION_DENIED;
+    }
+
     return handleResponseError(response, errorMessageFunction);
   };
 


### PR DESCRIPTION
Jira issue: VEGA-3425
Стенд http://ltumoyakov-3425-lanit-vega-builder.code013.org
## Описание изменений
Добавлена страница ошибки 'permission_denied' в роутер и переход на неё в случае если при логине сервер вернул ошибку с данным кодом
## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [ ] Документация: отражены все изменения в API конфигов и описаны важные особенности реализации или использования
- [ ] Конфигурационные файлы: новые файлы или изменения текущих были проверены в тестовых репозиториях

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [x] Коммиты: проименованы в соответствии с [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
### E2E Suite Jenkins link
http://jenkins-remote-ci-gpn-vega-builder.code013.org:8081/job/STAND-TOOLBOX/job/scenario-tests-on-demand/722/

### E2E Suite Screenshot
![image](https://user-images.githubusercontent.com/21119774/118116633-b2f9e800-b414-11eb-9206-088159ec48e8.png)

### Unit Tests Screenshot
![image](https://user-images.githubusercontent.com/21119774/115858292-f3d79000-a458-11eb-9a1a-e601b73954bb.png)


