### PR TITLE
[VEGA-3804] fix(ProjectNav): Скрыл отображение табов Экономика и Логика проектов

### DIFF
--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -66,8 +66,8 @@ describe('Header', () => {
       expect(screen.getByLabelText('Разделы проекта')).toBeInTheDocument();
       expect(screen.getByText('О проекте')).toBeInTheDocument();
       expect(screen.getByText('Ресурсная база')).toBeInTheDocument();
-      expect(screen.getByText('Логика проекта')).toBeInTheDocument();
-      expect(screen.getByText('Экономика проекта')).toBeInTheDocument();
+      // expect(screen.getByText('Логика проекта')).toBeInTheDocument();
+      // expect(screen.getByText('Экономика проекта')).toBeInTheDocument();
     });
 
     test('управляет переходом по вкладкам', async () => {

--- a/src/components/Header/ProjectView/ProjectNav.tsx
+++ b/src/components/Header/ProjectView/ProjectNav.tsx
@@ -35,7 +35,7 @@ export const ProjectNav: React.FC<Props> = (props) => {
     () => [
       { name: 'О проекте', url: `/projects/show/${vid}`, testId: testId.about },
       { name: 'Ресурсная база', url: `/projects/show/${vid}/rb`, testId: testId.rb },
-      // { name: 'Логгика проекта', url: `/projects/show/${vid}/lc`, testId: testId.lc },
+      // { name: 'Логика проекта', url: `/projects/show/${vid}/lc`, testId: testId.lc },
       // {
       //   name: 'Экономика проекта',
       //   url: `/projects/show/${vid}/fem`,

--- a/src/components/Header/ProjectView/ProjectNav.tsx
+++ b/src/components/Header/ProjectView/ProjectNav.tsx
@@ -35,7 +35,7 @@ export const ProjectNav: React.FC<Props> = (props) => {
     () => [
       { name: 'О проекте', url: `/projects/show/${vid}`, testId: testId.about },
       { name: 'Ресурсная база', url: `/projects/show/${vid}/rb`, testId: testId.rb },
-      { name: 'Логика проекта', url: `/projects/show/${vid}/lc`, testId: testId.lc },
+      { name: 'Логгика проекта', url: `/projects/show/${vid}/lc`, testId: testId.lc },
       {
         name: 'Экономика проекта',
         url: `/projects/show/${vid}/fem`,

--- a/src/components/Header/ProjectView/ProjectNav.tsx
+++ b/src/components/Header/ProjectView/ProjectNav.tsx
@@ -35,12 +35,12 @@ export const ProjectNav: React.FC<Props> = (props) => {
     () => [
       { name: 'О проекте', url: `/projects/show/${vid}`, testId: testId.about },
       { name: 'Ресурсная база', url: `/projects/show/${vid}/rb`, testId: testId.rb },
-      { name: 'Логгика проекта', url: `/projects/show/${vid}/lc`, testId: testId.lc },
-      {
-        name: 'Экономика проекта',
-        url: `/projects/show/${vid}/fem`,
-        testId: testId.fem,
-      },
+      // { name: 'Логгика проекта', url: `/projects/show/${vid}/lc`, testId: testId.lc },
+      // {
+      //   name: 'Экономика проекта',
+      //   url: `/projects/show/${vid}/fem`,
+      //   testId: testId.fem,
+      // },
     ],
     [vid],
   );


### PR DESCRIPTION
## Problem statement
Скрыть отображение табов Экономика и Логика проектов

_{VEGA-3804}_

## Solution details

_Скрыл отображение табов Экономика и Логика проектов (ProjectNav)_
Стенд: http://db-3804-lanit-vega-builder.code013.org
## Type
- [ ] Feature
- [x] Bug Fix
- [ ] Refactoring
- [ ] Test
- [ ] Other

## Associated issues

_{Jira issues or PRs related to this one}_

## Quality control
- [x] PR: Based on a correct branch
- [x] PR: Head branch is rebased on the base branch
- [x] PR: Assignee chosen and necessary labels are set
- [x] PR: Current form is filled out (where it makes sense)
- [x] PR: Diff checked for irrelevant changes
- [x] PR: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specs
- [x] PR: Checked for spelling, grammar and typos
- [x] Docs: All the important changes and features are described
- [ ] Tests: New unit tests developed
- [ ] Tests: New E2E tests developed
- [x] Tests: Existing unit tests passed successfully
- [x] Tests: Existing E2E tests passed successfully
- [x] Tests: Manually tested on personal instance
![image](https://user-images.githubusercontent.com/65446124/118142041-337c1100-b434-11eb-9491-8fac1c553d66.png)

## Notable statements
- [ ] Affects configuration files
- [ ] Brings new packages or updates existing
- [ ] Opened follow-up tasks to resolve
