### PR TITLE
[VEGA-3784] feat(global): Добавление возможности включения/выключения режима использования SSO при запуске FE

### DIFF
--- a/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
+++ b/src/components/ApplicationRoutes/ApplicationRoutes.test.tsx
@@ -54,6 +54,10 @@ describe('ApplicationRoutes', () => {
   });
 
   describe('авторизация', () => {
+    beforeEach(() => {
+      process.env.DISABLE_SSO = 'true';
+    });
+
     test('при авторизации по умолчанию происходит редирект на страницу проектов', async () => {
       fetchMock.mock(`/auth/jwt/obtain`, {
         first_name: 'First',
@@ -73,7 +77,7 @@ describe('ApplicationRoutes', () => {
     });
 
     test('корректно работает авторизация через SSO', async () => {
-      localStorage.setItem('useUnstableAuthSSO', 'true');
+      process.env.DISABLE_SSO = 'false';
 
       fetchMock.mock(`/auth/sso/login`, {
         first_name: 'First',

--- a/src/components/AuthPage/AuthPage.test.tsx
+++ b/src/components/AuthPage/AuthPage.test.tsx
@@ -23,7 +23,7 @@ describe('AuthPage', () => {
   });
 
   describe('авторизация по логину и паролю', () => {
-    beforeEach(() => {
+    beforeAll(() => {
       process.env.DISABLE_SSO = 'true';
     });
 
@@ -98,7 +98,7 @@ describe('AuthPage', () => {
   });
 
   describe('авторизация через SSO', () => {
-    beforeEach(() => {
+    beforeAll(() => {
       process.env.DISABLE_SSO = 'false';
     });
 

--- a/src/components/AuthPage/AuthPage.test.tsx
+++ b/src/components/AuthPage/AuthPage.test.tsx
@@ -23,6 +23,10 @@ describe('AuthPage', () => {
   });
 
   describe('авторизация по логину и паролю', () => {
+    beforeEach(() => {
+      process.env.DISABLE_SSO = 'true';
+    });
+
     test('успешная авторизация', async () => {
       fetchMock.mock(`/auth/jwt/obtain`, {
         first_name: 'First',
@@ -95,7 +99,7 @@ describe('AuthPage', () => {
 
   describe('авторизация через SSO', () => {
     beforeEach(() => {
-      localStorage.setItem('useUnstableAuthSSO', 'true');
+      process.env.DISABLE_SSO = 'false';
     });
 
     test('успешная авторизация', async () => {

--- a/src/components/AuthPage/AuthPage.tsx
+++ b/src/components/AuthPage/AuthPage.tsx
@@ -43,9 +43,10 @@ export const AuthPage: AuthPageType = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const useUnstableAuthSSO = localStorage.getItem('useUnstableAuthSSO');
+    const useAuthWithoutSSO = process.env.DISABLE_SSO === 'true';
+    const manuallyDisableSSO = localStorage.getItem('disableSSO') === 'true';
 
-    if (useUnstableAuthSSO === 'true') {
+    if (!useAuthWithoutSSO && !manuallyDisableSSO) {
       if (notifications.find(LOGIN_SSO_ERROR_NOTIFICATION_KEY) !== undefined) {
         notifications.remove(LOGIN_SSO_ERROR_NOTIFICATION_KEY);
       }

--- a/src/testing/configure-shell.ts
+++ b/src/testing/configure-shell.ts
@@ -63,6 +63,9 @@ function createSchemaLink(resolvers: SchemaResolvers): SchemaLink {
 export const configureShell = (options: Options = {}): Shell => {
   const { user: userOpts, isAuth = false, baseApiUrl = '', resolvers } = options;
 
+  process.env.DISABLE_SSO =
+    process.env.DISABLE_SSO !== undefined ? process.env.DISABLE_SSO : 'true';
+
   if (isAuth) {
     const user: User = {
       firstName: userOpts?.firstName ?? 'First',

--- a/src/vega-shell.test.ts
+++ b/src/vega-shell.test.ts
@@ -5,6 +5,10 @@ describe('точка входа', () => {
 
   document.body.appendChild(mountNode);
 
+  beforeAll(() => {
+    process.env.DISABLE_SSO = 'true';
+  });
+
   test('запускается без ошибок', async () => {
     await import('./vega-shell');
     expect(mountNode).toBeInTheDocument();


### PR DESCRIPTION
Jira issue: VEGA-3784
stand: http://ltumoyakov-3784-2-lanit-vega-builder.code013.org

## Problem statement

[VEGA-3784](https://jira.vegaspace.tk/browse/VEGA-3784)

## Solution details

- Установлен по умолчанию режим авторизации через SSO
- Добавлена возможность отключения данного режима с помощью env переменной DISABLE_SSO и localStorage - disableSSO

## Type
- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Test
- [ ] Other

## Associated issues

[исправление тестов](https://git.konakov.tv/vega2/vega-scenario-tests/-/merge_requests/41)

## Quality control
- [x] PR: Based on a correct branch
- [x] PR: Head branch is rebased on the base branch
- [x] PR: Assignee chosen and necessary labels are set
- [ ] PR: Current form is filled out (where it makes sense)
- [x] PR: Diff checked for irrelevant changes
- [x] PR: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specs
- [x] PR: Checked for spelling, grammar and typos
- [ ] Docs: All the important changes and features are described
- [ ] Tests: New unit tests developed
- [ ] Tests: New E2E tests developed
- [x] Tests: Existing unit tests passed successfully
- [ ] Tests: Existing E2E tests passed successfully
- [ ] Tests: Manually tested on personal instance

## Notable statements
- [ ] Affects configuration files
- [ ] Brings new packages or updates existing
- [ ] Opened follow-up tasks to resolve

### E2E Suite Jenkins link
http://jenkins-remote-ci-gpn-vega-builder.code013.org:8081/job/STAND-TOOLBOX/job/scenario-tests-on-demand/838/
### E2E Suite Screenshot
![image](https://user-images.githubusercontent.com/21119774/120463736-e17c3a80-c3a4-11eb-88a4-61f6b062e623.png)

### Unit Tests Screenshot
![image](https://user-images.githubusercontent.com/21119774/120436938-38bfe200-c388-11eb-829e-7dddff3318f4.png)
