### PR TITLE
[VEGA-3402] fix(graphql): удаление localProject из UpdateProjectDiff

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -10441,22 +10441,10 @@
       {
         "kind": "OBJECT",
         "name": "UpdateProjectDiff",
-        "description": "Contains remote and local versions of  project if versions are not equal.",
+        "description": "Contains remote version of  project if versions are not equal.",
         "fields": [
           {
             "name": "remoteProject",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Project",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "localProject",
             "description": null,
             "args": [],
             "type": {
@@ -11766,11 +11754,7 @@
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -11792,11 +11776,7 @@
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -11818,10 +11798,7 @@
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD_DEFINITION",
-          "ENUM_VALUE"
-        ],
+        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
         "args": [
           {
             "name": "reason",
@@ -11839,9 +11816,7 @@
         "name": "specifiedBy",
         "description": "Exposes a URL that specifies the behaviour of this scalar.",
         "isRepeatable": false,
-        "locations": [
-          "SCALAR"
-        ],
+        "locations": ["SCALAR"],
         "args": [
           {
             "name": "url",

--- a/schema.graphql
+++ b/schema.graphql
@@ -837,7 +837,6 @@ union ProjectDiffOrError = Project | UpdateProjectDiff | Error | ValidationError
 """Contains remote and local versions of  project if versions are not equal."""
 type UpdateProjectDiff {
   remoteProject: Project
-  localProject: Project
   message: String
 }
 input ProjectUpdateType {


### PR DESCRIPTION
## Задача
Задача в Jira GPN: https://jira.konakov.tv/browse/VEGA-3402
stand: http://ltumoyakov-3402-lanit-vega-builder.code013.org

## Solution details

Убран возврат клиентской версии обратно с сервера.

## Type
- [ ] Feature
- [ ] Bug Fix
- [x] Refactoring
- [ ] Test
- [ ] Other

## Associated issues

[rb](https://github.com/gpn-prototypes/vega-rb/pull/153)
[sp](https://github.com/gpn-prototypes/vega-sp/pull/204)
[backend](https://git.konakov.tv/vega2/vega2-back-core/-/merge_requests/503)

## Quality control
- [x] PR: Based on a correct branch
- [x] PR: Head branch is rebased on the base branch
- [x] PR: Assignee chosen and necessary labels are set
- [x] PR: Current form is filled out (where it makes sense)
- [x] PR: Diff checked for irrelevant changes
- [x] PR: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specs
- [x] PR: Checked for spelling, grammar and typos
- [ ] Docs: All the important changes and features are described
- [ ] Tests: New unit tests developed
- [ ] Tests: New E2E tests developed
- [x] Tests: Existing unit tests passed successfully
- [x] Tests: Existing E2E tests passed successfully
- [ ] Tests: Manually tested on personal instance

## Notable statements
- [ ] Affects configuration files
- [ ] Brings new packages or updates existing
- [ ] Opened follow-up tasks to resolve

### E2E Suite Jenkins link
http://jenkins-remote-ci-gpn-vega-builder.code013.org:8081/job/STAND-TOOLBOX/job/scenario-tests-on-demand/956/

### E2E Suite Screenshot
![image](https://user-images.githubusercontent.com/21119774/122002348-4cbd0800-cdba-11eb-919d-d6472b3bff87.png)

### Unit Tests Screenshot
![image](https://user-images.githubusercontent.com/21119774/122002657-b89f7080-cdba-11eb-8521-af716b45f4a3.png)